### PR TITLE
Hooks to run after LE-Code

### DIFF
--- a/k_stdlib/OSCache.h
+++ b/k_stdlib/OSCache.h
@@ -1,0 +1,8 @@
+#pragma once
+
+extern "C" {
+
+void DCFlushRange(void * ptr, u32 size);
+void ICInvalidateRange(void * ptr, u32 size);
+
+}

--- a/symbols.txt
+++ b/symbols.txt
@@ -1,6 +1,9 @@
 OSReport = 0x801A25D0
 strcmp = 0x8001329c
 
+DCFlushRange = 0x801a162c
+ICInvalidateRange = 0x801a1710
+
 settings = 0x80004004
 
 inputdata = 0x809bd70c

--- a/vp/lecode.cpp
+++ b/vp/lecode.cpp
@@ -2,20 +2,9 @@
 #include <dvd.h>
 #include <base/rvl_sdk.h>
 
-struct LECTHeader
-{
-    u32 magic;
-    u32 version;
-    u32 buildNum;
-    void * loadAddress;
-    void (*mainFunc)();
-    u32 size;
-    u32 paramSectionOffset;
-    char region;
-    char debugFlag;
-    u8 leVersion;
-    u8 _1f;
-};
+#include "lecode.h"
+
+PostLECodeHook * PostLECodeHook::sHooks = NULL;
 
 static void notFoundError()
 {
@@ -63,7 +52,10 @@ static int loadLECode()
     LECTHeader * newHeader = (LECTHeader *) header.loadAddress;
     newHeader->mainFunc();
 
+    // Call post LE-Code hooks
+    PostLECodeHook::exec();
+
     return 0;
 }
 
-kmOnLoad(loadLECode);
+kmBranch(0x800074d4, loadLECode);

--- a/vp/lecode.h
+++ b/vp/lecode.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <kamek.h>
+#include <OSCache.h>
+
+struct LECTHeader
+{
+    u32 magic;
+    u32 version;
+    u32 buildNum;
+    void * loadAddress;
+    void (*mainFunc)();
+    u32 size;
+    u32 paramSectionOffset;
+    char region;
+    char debugFlag;
+    u8 leVersion;
+    u8 _1f;
+};
+
+class PostLECodeHook {
+public:
+    enum Mode {
+        BRANCH,
+        BRANCH_LINK,
+        WRITE32
+    };
+
+private:
+    u32 mAddr;
+    u32 mVal;
+    Mode mMode;
+
+    PostLECodeHook * mNext;
+    static PostLECodeHook * sHooks;
+
+    void patch() {
+        if (mMode == WRITE32) {
+            *(u32 *)mAddr = mVal;
+        }
+        else {
+            u32 delta = (mVal - mAddr) & 0x3FFFFFF;
+            u32 instr = 0x48000000 | delta;
+            if (mMode == BRANCH_LINK)
+                instr |= 1;
+
+            *(u32 *)mAddr = instr;
+        }
+
+        DCFlushRange((void *)mAddr, sizeof(mVal));
+        ICInvalidateRange((void *)mAddr, sizeof(mVal));
+    }
+
+public:
+    /*
+        addr will not be autoported, use & of a symbol for that
+        
+        val depends on mode:
+            BRANCH[_LINK]: function to branch to
+            WRITE32: word to write
+    */
+    template <typename T1, typename T2>
+    PostLECodeHook(T1 addr, T2 val, Mode mode) {
+        mNext = sHooks;
+        sHooks = this;
+
+        mAddr = (u32)addr;
+        mVal = (u32)val;
+        mMode = mode;
+    }
+
+    static void exec() {
+        for (PostLECodeHook * p = sHooks; p; p = p->mNext)
+            p->patch();
+    }
+};


### PR DESCRIPTION
Adds PostLECodeHook, which allows hooks to be applied after LE-Code has ran to take control of any conflicts. It can be used like `static PostLECodeHook exampleHook(&symbol, val, mode);`. The available modes are:
- BRANCH: write a b at `symbol` to function `val`
- BRANCH_LINK: write a bl at `symbol` to function `val`
- WRITE32: write the 32-byte value `val` at `symbol`

Raw addresses are not autoported by kamek here, so a symbol has to be used.

These hooks are applied at 0x800074d4 PAL, which runs slightly after the kamek payload (and therefore after LE-Code)